### PR TITLE
10 be add platformfee calculation in payment service

### DIFF
--- a/controller/transaction_router.py
+++ b/controller/transaction_router.py
@@ -15,6 +15,7 @@ transaction_router = APIRouter()
     response_model=GetTransactionDetailsOut,
     responses={
         400: {'model': Message, 'description': 'Bad request'},
+        422: {'model': Message, 'description': 'Unprocessable Entity'},
         500: {'model': Message, 'description': 'Internal server error'},
     },
     summary='Get Transaction total for fees',

--- a/model/transaction/transaction.py
+++ b/model/transaction/transaction.py
@@ -18,8 +18,8 @@ class GetTransactionDetailsIn(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    platform_fee: Optional[Price] = None
     ticket_price: Price
+    platform_fee: Optional[Price] = Field(None, description='Percent platform fee')
     payment_method: PaymentMethod = Field(..., title='Payment Method')
     payment_channel: Union[DirectDebitChannels, EWalletChannels] = Field(..., title='Payment Channel')
 
@@ -30,5 +30,5 @@ class GetTransactionDetailsOut(BaseModel):
 
     ticket_price: Price
     transaction_fee: Price
-    total_price: Price
     platform_fee: Optional[Price] = None
+    total_price: Price

--- a/model/transaction/transaction.py
+++ b/model/transaction/transaction.py
@@ -18,6 +18,7 @@ class GetTransactionDetailsIn(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    platform_fee: Optional[Price] = None
     ticket_price: Price
     payment_method: PaymentMethod = Field(..., title='Payment Method')
     payment_channel: Union[DirectDebitChannels, EWalletChannels] = Field(..., title='Payment Channel')
@@ -30,3 +31,4 @@ class GetTransactionDetailsOut(BaseModel):
     ticket_price: Price
     transaction_fee: Price
     total_price: Price
+    platform_fee: Optional[Price] = None

--- a/model/transaction/transaction.py
+++ b/model/transaction/transaction.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Union
+from typing import Union, Optional, TypeAlias
 
 from pydantic import BaseModel, Extra, Field
 from typing_extensions import Annotated
@@ -11,11 +11,14 @@ from model.payment.payment_constants import (
 )
 
 
+Price: TypeAlias = Annotated[Decimal, Field(decimal_places=2)]
+
+
 class GetTransactionDetailsIn(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    ticket_price: Annotated[Decimal, Field(decimal_places=2)]
+    ticket_price: Price
     payment_method: PaymentMethod = Field(..., title='Payment Method')
     payment_channel: Union[DirectDebitChannels, EWalletChannels] = Field(..., title='Payment Channel')
 
@@ -24,6 +27,6 @@ class GetTransactionDetailsOut(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    ticket_price: Annotated[Decimal, Field(decimal_places=2)]
-    transaction_fee: Annotated[Decimal, Field(decimal_places=2)]
-    total_price: Annotated[Decimal, Field(decimal_places=2)]
+    ticket_price: Price
+    transaction_fee: Price
+    total_price: Price

--- a/usecase/transaction_usecase.py
+++ b/usecase/transaction_usecase.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from sympy import Eq, solve, symbols
 
 from model.payment.payment_constants import EWalletChannels, PaymentMethod
@@ -10,7 +11,9 @@ from model.transaction.transaction import (
 class TransactionUsecase:
     def get_transaction_details(self, get_transaction_details_in: GetTransactionDetailsIn):
         e_wallet_fee_map = {EWalletChannels.GCASH.value: 0.023, EWalletChannels.PAYMAYA.value: 0.018}
-        ticket_price = get_transaction_details_in.ticket_price
+        platform_fee = get_transaction_details_in.platform_fee or Decimal(0.00)  # resolve None to 0
+        ticket_price = get_transaction_details_in.ticket_price + platform_fee
+
         vat = 0.12
 
         # Define the symbol P (the price we want to find)
@@ -39,5 +42,6 @@ class TransactionUsecase:
         return GetTransactionDetailsOut(
             ticket_price=round(ticket_price, 2),
             total_price=round(total_price, 2),
+            platform_fee=round(platform_fee, 2),
             transaction_fee=round(transaction_fee, 2),
         )

--- a/usecase/transaction_usecase.py
+++ b/usecase/transaction_usecase.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from fastapi.responses import JSONResponse
 from sympy import Eq, solve, symbols
 
 from model.payment.payment_constants import EWalletChannels, PaymentMethod
@@ -32,6 +33,9 @@ class TransactionUsecase:
 
             is_fee_greater_than_default = ticket_price > min_ticket_price_for_default
             transaction_fee = (P * transaction_fee_percentage) if is_fee_greater_than_default else default_fee
+
+        else:
+            return JSONResponse(status_code=422, content={'message': 'Invalid payment method was passed.'})
 
         equation = Eq(P - transaction_fee - (transaction_fee * vat), ticket_price)
 


### PR DESCRIPTION
Add calculation for an optional percent `platform_fee` in `controller/transaction_router.py`.

Also added an error-handling catch for invalid `payment_method` to get rid of diagnostic warning.