### PR TITLE
fix: update devcontainer environment and resolve uvicorn/xendit dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,18 @@
 {
   "name": "SPARCS Payment Service",
-  "image": "mcr.microsoft.com/devcontainers/universal:latest",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.8"
+      "version": "3.10"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1.1.2": {
+      
     }
   },
-  "postCreateCommand": "pip install pipenv && npm install && pipenv install",
+  "postCreateCommand": "pip install pipenv && npm install && pipenv install --skip-lock --python 3.10",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -20,5 +23,8 @@
       ]
     }
   },
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/root/.aws,type=bind,consistency=cached"  
+  ],
   "remoteUser": "root"
 }

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ lambda-warmer-py = "==0.6.0"
 python-dotenv = "==1.0.0"
 pydantic = {version = "<2", extras = ["email"]}
 lambda-decorators = "==0.6.0"
-xendit-python = {git = "https://github.com/xendit/xendit-python.git"}
+xendit-python = { git = "https://github.com/xendit/xendit-python.git", ref = "master" }
 sympy = "==1.12"
 requests = "==2.32.3"
 boto3 = "==1.22.7"


### PR DESCRIPTION
### Resolves issue #23 

## Deliverables:
- Bumped Python version to `3.10`
- Working `.devcontainer` setup
- `aws-cli` added as a devcontainer feature and mounted `.aws` credentials into container

## Commits:
feat: added aws-cli and mounted credentials to container

fix: devcontainers not finshing pipenv install due to uvicorn version and xendit git branch

### Note: 
`--skip-lock` was used to prevent dependency errors with uvicorn's version